### PR TITLE
Admin/invoice/us 33

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -7,4 +7,8 @@ class Customer < ApplicationRecord
   
   validates :first_name, presence: true
   validates :last_name, presence: true
+
+  def full_name
+    "#{self.first_name} #{self.last_name}"
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,4 +7,8 @@ class Invoice < ApplicationRecord
   validates :status, presence: true
 
   enum :status, {"in progress": 0, "completed": 1, "cancelled": 2}
+
+  def date_format
+    self.created_at.strftime("%A, %B %d, %Y")
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,1 +1,8 @@
-<h1>Invoice <%= @invoice.id %> Show Page </h1>
+<h1>Invoice ID #<%= @invoice.id %> Show Page </h1>
+
+<section class="invoice-details">
+  <p><strong>ID:</strong> #<%= @invoice.id %></p>
+  <p><strong>Status:</strong> <%= @invoice.status %></p>
+  <p><strong>Customer:</strong> <%= @invoice.customer.full_name %></p>
+  <p><strong>Created Date:</strong> <%= @invoice.date_format %></p>
+</section>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Admin Invoices Index Page" do
+  before :each do
+    @invoice1 = create(:invoice) # automatically create associated customer, transactions and invoice_items
+  end
+
+  # US 33
+  it "lists all of the invoice details on the show page" do
+    visit admin_invoice_path(@invoice1.id)
+
+    expect(page).to have_content("ID: ##{@invoice1.id}")
+    expect(page).to have_content("Status: #{@invoice1.status}")
+    expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
+    expect(page).to have_content("Created Date: #{@invoice1.date_format}")
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe Customer, type: :model do
   before :each do
     @customer = create(:customer)
-    # @item_1 = create(:item)
   end
 
   describe "relationships" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Customer, type: :model do
+  before :each do
+    @customer = create(:customer)
+    # @item_1 = create(:item)
+  end
+
   describe "relationships" do
     it { should have_many(:invoices)}
     it { should have_many(:transactions).through(:invoices) }
@@ -12,5 +17,13 @@ RSpec.describe Customer, type: :model do
   describe "validations" do
     it {should validate_presence_of(:first_name)}
     it {should validate_presence_of(:last_name)}
+  end
+
+  describe "instance methods" do
+    describe "#full_name" do
+      it "can return the full name of the customer'" do
+        expect(@customer.full_name).to eq("#{@customer.first_name} #{@customer.last_name}")
+      end
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Invoice, type: :model do
+  before :each do
+    @date = DateTime.new(2012, 3, 10)
+    @invoice1 = create(:invoice, created_at: @date) # automatically create associated customer, transactions and invoice_items
+  end
   describe "relationships" do
     it { should have_many(:invoice_items) }
     it { should belong_to(:customer) }
@@ -10,5 +14,13 @@ RSpec.describe Invoice, type: :model do
 
   describe 'validations' do
     it {should validate_presence_of :status}
+  end
+
+  describe "instance methods" do
+    describe "#date_format" do
+      it "can return the created_at date formatted as 'day_of_week, full_month padded_day, year'" do
+        expect(@invoice1.date_format).to eq("Saturday, March 10, 2012")
+      end
+    end
   end
 end


### PR DESCRIPTION
33. Admin Invoice Show Page

As an admin,
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
Then I see information related to that invoice including:
- Invoice id
- Invoice status
- Invoice created_at date in the format "Monday, July 18, 2019"
- Customer first and last name

& respective model tests for #full_name, #date_format