### PR TITLE
Admin/invoice/us 34

### DIFF
--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -4,3 +4,12 @@
   <p><strong>Customer:</strong> <%= @invoice.customer.full_name %></p>
   <p><strong>Created Date:</strong> <%= @invoice.date_format %></p>
 </section>
+
+<% @invoice.invoice_items.each do |invoice_item| %>
+  <section id="invoice-item-<%= invoice_item.id %>"></p>
+    <p>Item: <%= invoice_item.item.name %></p>
+    <p>Quantity Ordered: <%= invoice_item.quantity %></p>
+    <p>Sold Price: <%= invoice_item.unit_price %></p>
+    <p>Invoice Item Status: <%= invoice_item.status %></p>
+  </section>
+<% end %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :item do
     name { Faker::Commerce.product_name }
     description { Faker::Lorem.sentence }
-    unit_price { Faker::Number.number(digits: 5) } # adjust range as necessary
+    unit_price { Faker::Number.number(digits: 5) } 
     association :merchant
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -39,5 +39,5 @@ RSpec.describe "Admin Invoices Index Page" do
         expect(page).to have_content("Invoice Item Status: #{invoice_item.status}")
       end
     end
-  end
-end
+  end 
+end 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -2,7 +2,19 @@ require "rails_helper"
 
 RSpec.describe "Admin Invoices Index Page" do
   before :each do
-    @invoice1 = create(:invoice) # automatically create associated customer, transactions and invoice_items
+    @customer = create(:customer)
+    @invoice1 = create(:invoice, customer: @customer)
+    
+    # Create first item and associated invoice item
+    @item1 = create(:item) 
+    @invoice_item1 = create(:invoice_item, invoice: @invoice1, item: @item1)
+    
+    # Create second item and associated invoice item
+    @item2 = create(:item) 
+    @invoice_item2 = create(:invoice_item, invoice: @invoice1, item: @item2)
+
+    # Create a transaction for the invoice
+    create(:transaction, invoice: @invoice1) 
   end
 
   # US 33
@@ -13,5 +25,19 @@ RSpec.describe "Admin Invoices Index Page" do
     expect(page).to have_content("Status: #{@invoice1.status}")
     expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
     expect(page).to have_content("Created Date: #{@invoice1.date_format}")
+  end
+
+  # US 34
+  it "displays all invoice items and attributes" do
+    visit admin_invoice_path(@invoice1.id)
+
+    @invoice1.invoice_items.each do |invoice_item|
+      within("#invoice-item-#{invoice_item.id}") do
+        expect(page).to have_content("Item: #{invoice_item.item.name}")
+        expect(page).to have_content("Quantity Ordered: #{invoice_item.quantity}")
+        expect(page).to have_content("Sold Price: #{invoice_item.unit_price}")
+        expect(page).to have_content("Invoice Item Status: #{invoice_item.status}")
+      end
+    end
   end
 end


### PR DESCRIPTION
34. Admin Invoice Show Page: Invoice Item Information

As an admin
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
Then I see all of the items on the invoice including:
- Item name
- The quantity of the item ordered
- The price the Item sold for
- The Invoice Item status