### PR TITLE
Admin/invoice/us 36

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,20 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+
+  end
+
+  def update
+    invoice = Invoice.find(params[:id])
+
+    invoice.update({
+      status: params[:name]
+      })
+
+    invoice.save
+
+    redirect_to admin_invoice_path(invoice.id)
+  end
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -8,10 +8,6 @@ class Admin::InvoicesController < ApplicationController
   end
 
   def update
-
-  end
-
-  def update
     invoice = Invoice.find(params[:id])
 
     invoice.update({

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -11,4 +11,8 @@ class Invoice < ApplicationRecord
   def date_format
     self.created_at.strftime("%A, %B %d, %Y")
   end
+
+  def total_revenue
+    self.invoice_items.sum("quantity * unit_price")
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -3,6 +3,7 @@
   <p><strong>Status:</strong> <%= @invoice.status %></p>
   <p><strong>Customer:</strong> <%= @invoice.customer.full_name %></p>
   <p><strong>Created Date:</strong> <%= @invoice.date_format %></p>
+  <p><strong>Total Revenue:</strong> $<%= @invoice.total_revenue %></p>
 </section>
 
 <% @invoice.invoice_items.each do |invoice_item| %>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,6 +1,7 @@
 <section class="invoice-details">
   <p><strong>ID:</strong> #<%= @invoice.id %></p>
-  <p><strong>Status:</strong> <%= @invoice.status %></p>
+  <p><strong>Status:</strong> <%= select_tag 'invoice[status]', options_for_select(["in progress", "completed", "cancelled"], @invoice.status) %></p>
+  <%= button_to "Update Invoice Status", admin_invoice_path(@invoice), method: :patch, data: { turbo: false } %><br>
   <p><strong>Customer:</strong> <%= @invoice.customer.full_name %></p>
   <p><strong>Created Date:</strong> <%= @invoice.date_format %></p>
   <p><strong>Total Revenue:</strong> $<%= @invoice.total_revenue %></p>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -4,3 +4,12 @@
   <p><strong>Customer:</strong> <%= @invoice.customer.full_name %></p>
   <p><strong>Created Date:</strong> <%= @invoice.date_format %></p>
 </section>
+
+<% @invoice.invoice_items.each do |invoice_item| %>
+  <section id="invoice-item-<%= invoice_item.id %>"></p>
+    <p>Item: <%= invoice_item.item.name %></p>
+    <p>Quantity Ordered: <%= invoice_item.quantity %></p>
+    <p>Sold Price: <%= invoice_item.unit_price %></p>
+    <p>Invoice Item Status: <%= invoice_item.status %></p>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboards#welcome"
 
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
     resources :merchants, only: [:index, :show]
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :item do
     name { Faker::Commerce.product_name }
     description { Faker::Lorem.sentence }
-    unit_price { Faker::Number.number(digits: 5) } # adjust range as necessary
+    unit_price { Faker::Number.number(digits: 5) } 
     association :merchant
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -39,5 +39,5 @@ RSpec.describe "Admin Invoices Index Page" do
         expect(page).to have_content("Invoice Item Status: #{invoice_item.status}")
       end
     end
-  end
-end
+  end 
+end 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -40,4 +40,11 @@ RSpec.describe "Admin Invoices Index Page" do
       end
     end
   end 
+  
+  # US 35
+  it "displays the total revenue generated from the invoice" do
+    visit admin_invoice_path(@invoice1.id)
+
+    expect(page).to have_content("Total Revenue: $#{@invoice1.total_revenue}")
+  end
 end 

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -2,7 +2,19 @@ require "rails_helper"
 
 RSpec.describe "Admin Invoices Index Page" do
   before :each do
-    @invoice1 = create(:invoice) # automatically create associated customer, transactions and invoice_items
+    @customer = create(:customer)
+    @invoice1 = create(:invoice, customer: @customer)
+    
+    # Create first item and associated invoice item
+    @item1 = create(:item) 
+    @invoice_item1 = create(:invoice_item, invoice: @invoice1, item: @item1)
+    
+    # Create second item and associated invoice item
+    @item2 = create(:item) 
+    @invoice_item2 = create(:invoice_item, invoice: @invoice1, item: @item2)
+
+    # Create a transaction for the invoice
+    create(:transaction, invoice: @invoice1) 
   end
 
   # US 33
@@ -13,5 +25,19 @@ RSpec.describe "Admin Invoices Index Page" do
     expect(page).to have_content("Status: #{@invoice1.status}")
     expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
     expect(page).to have_content("Created Date: #{@invoice1.date_format}")
+  end
+
+  # US 34
+  it "displays all invoice items and attributes" do
+    visit admin_invoice_path(@invoice1.id)
+
+    @invoice1.invoice_items.each do |invoice_item|
+      within("#invoice-item-#{invoice_item.id}") do
+        expect(page).to have_content("Item: #{invoice_item.item.name}")
+        expect(page).to have_content("Quantity Ordered: #{invoice_item.quantity}")
+        expect(page).to have_content("Sold Price: #{invoice_item.unit_price}")
+        expect(page).to have_content("Invoice Item Status: #{invoice_item.status}")
+      end
+    end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Admin Invoices Index Page" do
     visit admin_invoice_path(@invoice1.id)
 
     expect(page).to have_content("ID: ##{@invoice1.id}")
-    expect(page).to have_content("Status: #{@invoice1.status}")
+    expect(page).to have_select('invoice[status]', selected: @invoice1.status)
     expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
     expect(page).to have_content("Created Date: #{@invoice1.date_format}")
   end
@@ -40,11 +40,22 @@ RSpec.describe "Admin Invoices Index Page" do
       end
     end
   end 
-  
+
   # US 35
   it "displays the total revenue generated from the invoice" do
     visit admin_invoice_path(@invoice1.id)
 
     expect(page).to have_content("Total Revenue: $#{@invoice1.total_revenue}")
+  end
+
+  # US 36
+  it "displays a select field for invoice status and updates the field" do
+    visit admin_invoice_path(@invoice1.id)
+
+    expect(page).to have_select('invoice[status]', selected: @invoice1.status)
+
+    select 'cancelled', from: 'invoice[status]'
+
+    expect(page).to have_select('invoice[status]', selected: 'cancelled')
   end
 end 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -22,5 +22,16 @@ RSpec.describe Invoice, type: :model do
         expect(@invoice1.date_format).to eq("Saturday, March 10, 2012")
       end
     end
+
+    describe "#total_revenue" do
+      it "can find the total revenue on an invoice" do
+        item1 = create(:item, unit_price: 100)
+        item2 = create(:item, unit_price: 200)
+        create(:invoice_item, invoice: @invoice1, item: item1, quantity: 2, unit_price: 100)
+        create(:invoice_item, invoice: @invoice1, item: item2, quantity: 3, unit_price: 200)
+
+        expect(@invoice1.total_revenue).to eq(800)
+      end
+    end
   end
 end


### PR DESCRIPTION
36. Admin Invoice Show Page: Update Invoice Status

As an admin     
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
I see the invoice status is a select field
And I see that the invoice's current status is selected
When I click this select field,
Then I can select a new status for the Invoice,
And next to the select field I see a button to "Update Invoice Status"
When I click this button
I am taken back to the admin invoice show page
And I see that my Invoice's status has now been updated


Created a select tag that updates the status attribute when the update button is clicked