### PR TITLE
Admin/merchant/us 26

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,20 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+
+  end
+
+  def update
+    invoice = Invoice.find(params[:id])
+
+    invoice.update({
+      status: params[:name]
+      })
+
+    invoice.save
+
+    redirect_to admin_invoice_path(invoice.id)
+  end
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -8,10 +8,6 @@ class Admin::InvoicesController < ApplicationController
   end
 
   def update
-
-  end
-
-  def update
     invoice = Invoice.find(params[:id])
 
     invoice.update({

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,4 +6,29 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    merchant = Merchant.find(params[:id])
+
+    if merchant.update({name: params[:name]})
+
+      merchant.save
+      redirect_to admin_merchant_path(merchant.id)
+      flash[:alert] = "Merchant Successfully Updated"
+    else
+      redirect_to admin_merchant_path(merchant.id)
+      flash[:alert] = "Merchant Unsuccessfully Updated"
+    end
+  end
+
+  # if pet.update(pet_params)
+  #   redirect_to "/pets/#{pet.id}"
+  # else
+  #   redirect_to "/pets/#{pet.id}/edit"
+  #   flash[:alert] = "Error: #{error_message(pet.errors)}"
+  # end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -24,11 +24,4 @@ class Admin::MerchantsController < ApplicationController
       flash[:alert] = "Merchant Unsuccessfully Updated"
     end
   end
-
-  # if pet.update(pet_params)
-  #   redirect_to "/pets/#{pet.id}"
-  # else
-  #   redirect_to "/pets/#{pet.id}/edit"
-  #   flash[:alert] = "Error: #{error_message(pet.errors)}"
-  # end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :alert
+  
   private
 
     def error_message(errors)

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,6 +1,7 @@
 <section class="invoice-details">
   <p><strong>ID:</strong> #<%= @invoice.id %></p>
-  <p><strong>Status:</strong> <%= @invoice.status %></p>
+  <p><strong>Status:</strong> <%= select_tag 'invoice[status]', options_for_select(["in progress", "completed", "cancelled"], @invoice.status) %></p>
+  <%= button_to "Update Invoice Status", admin_invoice_path(@invoice), method: :patch, data: { turbo: false } %><br>
   <p><strong>Customer:</strong> <%= @invoice.customer.full_name %></p>
   <p><strong>Created Date:</strong> <%= @invoice.date_format %></p>
   <p><strong>Total Revenue:</strong> $<%= @invoice.total_revenue %></p>

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Edit a Merchant</h1>
+<%= form_with url: admin_merchant_path(@merchant.id), method: :patch, data: { turbo: false } do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.submit 'Submit' %>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -2,4 +2,5 @@
 
 <%= @merchants.each do |merchant| %>
   <%= link_to "Merchant #{merchant.id}", admin_merchant_path(merchant.id) %><br>
+  <p>Merchant Name: <%= merchant.name %></p>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,6 +1,5 @@
 <h1> Index of Admin Merchants </h1>
 
 <%= @merchants.each do |merchant| %>
-  <%= link_to "Merchant #{merchant.id}", admin_merchant_path(merchant.id) %><br>
-  <p>Merchant Name: <%= merchant.name %></p>
+  <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @merchant.name %> Show Page</h1>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,2 @@
 <h1><%= @merchant.name %> Show Page</h1>
+<%= link_to "Update Merchant", edit_admin_merchant_path(@merchant.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboards#welcome"
 
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
     resources :merchants, only: [:index, :show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,6 @@ Rails.application.routes.draw do
     get "/", to: "dashboards#welcome"
 
     resources :invoices, only: [:index, :show, :update]
-    resources :merchants, only: [:index, :show]
+    resources :merchants, only: [:index, :show, :edit, :update]
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Admin Invoices Index Page" do
     visit admin_invoice_path(@invoice1.id)
 
     expect(page).to have_content("ID: ##{@invoice1.id}")
-    expect(page).to have_content("Status: #{@invoice1.status}")
+    expect(page).to have_select('invoice[status]', selected: @invoice1.status)
     expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
     expect(page).to have_content("Created Date: #{@invoice1.date_format}")
   end
@@ -40,11 +40,22 @@ RSpec.describe "Admin Invoices Index Page" do
       end
     end
   end 
-  
+
   # US 35
   it "displays the total revenue generated from the invoice" do
     visit admin_invoice_path(@invoice1.id)
 
     expect(page).to have_content("Total Revenue: $#{@invoice1.total_revenue}")
+  end
+
+  # US 36
+  it "displays a select field for invoice status and updates the field" do
+    visit admin_invoice_path(@invoice1.id)
+
+    expect(page).to have_select('invoice[status]', selected: @invoice1.status)
+
+    select 'cancelled', from: 'invoice[status]'
+
+    expect(page).to have_select('invoice[status]', selected: 'cancelled')
   end
 end 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -15,4 +15,20 @@ RSpec.describe "Admin Merchants Index", type: :feature do
     expect(page).to have_content(@merchant2.name)
     expect(page).to have_content(@merchant3.name)
   end
+
+  #   As an admin,
+# When I click on the name of a merchant from the admin merchants index page (/admin/merchants),
+# Then I am taken to that merchant's admin show page (/admin/merchants/:merchant_id)
+# And I see the name of that merchant
+  # US 25
+  it "clicking the name redirects to merchant admin show page and displays the name" do
+    visit admin_merchants_path
+
+    expect(page).to have_link("#{@merchant1.name} ##{@merchant1.id}")
+    click_link("#{@merchant1.name} ##{@merchant1.id}")
+
+    expect(current_path).to eq(admin_merchant_path(@merchant1.id))
+
+    expect(page).to have_content(@merchant1.name)
+  end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Merchants Index", type: :feature do
+  before :each do
+    @merchant1 = create(:merchant)
+    @merchant2 = create(:merchant)
+    @merchant3 = create(:merchant)
+  end
+
+  # US 24
+  it "displays the name of each merchant" do
+    visit admin_merchants_path
+
+    expect(page).to have_content(@merchant1.name)
+    expect(page).to have_content(@merchant2.name)
+    expect(page).to have_content(@merchant3.name)
+  end
+end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -8,7 +8,20 @@ RSpec.describe "Admin Merchant Shoe Page", type: :feature do
   end
 
   # US 26
-  xit "" do
+  it "displays a link to update merchant information" do
+    visit admin_merchant_path(@merchant1.id)
 
+    expect(page).to have_content("#{@merchant1.name} Show Page")
+    expect(page).to have_link("Update Merchant")
+    click_link("Update Merchant")
+
+    expect(current_path).to eq(edit_admin_merchant_path(@merchant1.id))
+
+    fill_in "Name", with: "Merchant 2.0"
+    click_on "Submit"
+
+    expect(current_path).to eq(admin_merchant_path(@merchant1.id))
+    expect(page).to have_content("Merchant 2.0 Show Page")
+    expect(page).to have_content("Merchant Successfully Updated")
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Merchant Shoe Page", type: :feature do
+  before :each do
+    @merchant1 = create(:merchant)
+    @merchant2 = create(:merchant)
+    @merchant3 = create(:merchant)
+  end
+
+  # US 26
+  xit "" do
+
+  end
+end


### PR DESCRIPTION
26. Admin Merchant Update

As an admin,
When I visit a merchant's admin show page (/admin/merchants/:merchant_id)
Then I see a link to update the merchant's information.
When I click the link
Then I am taken to a page to edit this merchant
And I see a form filled in with the existing merchant attribute information
When I update the information in the form and I click ‘submit’
Then I am redirected back to the merchant's admin show page where I see the updated information
And I see a flash message stating that the information has been successfully updated.

Created a link to update the Merchant name