### PR TITLE
Admin/merchant/us 30

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -64,15 +64,8 @@ class Merchant < ApplicationRecord
   end
 
   def total_revenue
-    invoices
-    .joins(:transactions)
+    invoices.joins(:transactions)
     .where(transactions: { result: 0 }) # Filter by successful transactions
     .sum('invoice_items.unit_price * invoice_items.quantity')
   end
 end
-
-
-# expect("#{@merchant2.name}: #{@total_revenue2}").to appear_before("#{@merchant3.name}: #{@total_revenue3}")
-#     expect("#{@merchant3.name}: #{@total_revenue3}").to appear_before("#{@merchant4.name}: #{@total_revenue4}")
-#     expect("#{@merchant4.name}: #{@total_revenue4}").to appear_before("#{@merchant5.name}: #{@total_revenue5}")
-#     expect("#{@merchant5.name}: #{@total_revenue5}").to_not appear_before("#{@merchant1.name}: #{@total_revenue1}")

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -53,4 +53,26 @@ class Merchant < ApplicationRecord
     .order("sum(invoice_items.unit_price) DESC")
     .limit(5)
   end
+
+  def self.top_five_merchants_by_revenue
+    joins(:transactions) # join necessary tables
+    .where('transactions.result = 0') # filter by successful transactions 
+    .group('merchants.id') # group records by merchant
+    .select('merchants.*, SUM(invoice_items.unit_price * invoice_items.quantity) AS total_revenue')  # Calculate total revenue
+    .order('total_revenue DESC')
+    .limit(5)
+  end
+
+  def total_revenue
+    invoices
+    .joins(:transactions)
+    .where(transactions: { result: 0 }) # Filter by successful transactions
+    .sum('invoice_items.unit_price * invoice_items.quantity')
+  end
 end
+
+
+# expect("#{@merchant2.name}: #{@total_revenue2}").to appear_before("#{@merchant3.name}: #{@total_revenue3}")
+#     expect("#{@merchant3.name}: #{@total_revenue3}").to appear_before("#{@merchant4.name}: #{@total_revenue4}")
+#     expect("#{@merchant4.name}: #{@total_revenue4}").to appear_before("#{@merchant5.name}: #{@total_revenue5}")
+#     expect("#{@merchant5.name}: #{@total_revenue5}").to_not appear_before("#{@merchant1.name}: #{@total_revenue1}")

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -55,17 +55,10 @@ class Merchant < ApplicationRecord
   end
 
   def self.top_five_merchants_by_revenue
-    joins(:transactions) # join necessary tables
-    .where('transactions.result = 0') # filter by successful transactions 
-    .group('merchants.id') # group records by merchant
+    joins(invoices: [:invoice_items, :transactions]) # join necessary tables
+    .where("transactions.result = '0'") # filter by successful transactions 
     .select('merchants.*, SUM(invoice_items.unit_price * invoice_items.quantity) AS total_revenue')  # Calculate total revenue
+    .group('merchants.id') # group records by merchant
     .order('total_revenue DESC')
-    .limit(5)
-  end
-
-  def total_revenue
-    invoices.joins(:transactions)
-    .where(transactions: { result: 0 }) # Filter by successful transactions
-    .sum('invoice_items.unit_price * invoice_items.quantity')
   end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,13 +1,14 @@
 <h1> Index of Admin Merchants </h1>
 
-<%= @merchants.each do |merchant| %>
+<% @merchants.each do |merchant| %>
   <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
 <% end %>
+<br>
 
 <h3>Top 5 Merchants by Revenue</h3>
-<%= @merchants.top_five_merchants_by_revenue.each do |merchant| %>
-  <section id="admin-<%= merchant.id %>"></p>
+<% @merchants.top_five_merchants_by_revenue.each do |merchant| %>
+  <div id="merchant-<%= merchant.id %>">
     <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
-    <p><%= merchant.name%>: <%= merchant.total_revenue %></p>
-  </section>
+    <p><%= merchant.name %>: $<%= merchant.total_revenue %></p>
+  </div>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,14 +1,18 @@
 <h1> Index of Admin Merchants </h1>
-
-<% @merchants.each do |merchant| %>
-  <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
-<% end %>
 <br>
-
 <h3>Top 5 Merchants by Revenue</h3>
 <% @merchants.top_five_merchants_by_revenue.each do |merchant| %>
-  <div id="merchant-<%= merchant.id %>">
+  <div id="top_5-<%= merchant.id %>"> 
     <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
     <p><%= merchant.name %>: $<%= merchant.total_revenue %></p>
   </div>
 <% end %>
+<br>
+<h3>
+<% @merchants.each do |merchant| %>
+  <section id="merchant-<%= merchant.id %>"> 
+    <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
+  </section>
+<% end %>
+<br>
+

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -3,3 +3,11 @@
 <%= @merchants.each do |merchant| %>
   <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
 <% end %>
+
+<h3>Top 5 Merchants by Revenue</h3>
+<%= @merchants.top_five_merchants_by_revenue.each do |merchant| %>
+  <section id="admin-<%= merchant.id %>"></p>
+    <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
+    <p><%= merchant.name%>: <%= merchant.total_revenue %></p>
+  </section>
+<% end %>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -9,12 +9,26 @@ RSpec.describe "Admin Merchants Index", type: :feature do
     @merchant4 = create(:merchant)
     @merchant5 = create(:merchant)
 
-    # Create invoices with successful transactions
-    @invoice1 = create(:invoice) # No need to associate with a merchant
-    @invoice2 = create(:invoice) # No need to associate with a merchant
-    @invoice3 = create(:invoice) # No need to associate with a merchant
-    @invoice4 = create(:invoice) # No need to associate with a merchant
-    @invoice5 = create(:invoice) # No need to associate with a merchant
+    puts "Merchant 1 ID: #{@merchant1.id}"
+    puts "Merchant 1 Name: #{@merchant1.name}"
+
+    @customer1 = create(:customer)
+    @customer2 = create(:customer)
+    @customer3 = create(:customer)
+    @customer4 = create(:customer)
+    @customer5 = create(:customer)
+
+    @invoice1 = create(:invoice, customer: @customer1)
+    @invoice2 = create(:invoice, customer: @customer2)
+    @invoice3 = create(:invoice, customer: @customer3)
+    @invoice4 = create(:invoice, customer: @customer4)
+    @invoice5 = create(:invoice, customer: @customer5)
+
+    @item1 = create(:item, merchant: @merchant1)
+    @item2 = create(:item, merchant: @merchant2)
+    @item3 = create(:item, merchant: @merchant3)
+    @item4 = create(:item, merchant: @merchant4)
+    @item5 = create(:item, merchant: @merchant5)
 
     # Create invoice items with unit prices and quantities associated with invoices
     @invoice_item1 = create(:invoice_item, invoice: @invoice1, unit_price: 10, quantity: 5)
@@ -52,25 +66,14 @@ RSpec.describe "Admin Merchants Index", type: :feature do
     expect(page).to have_content(@merchant1.name)
   end
 
-  # As an admin,
-  # When I visit the admin merchants index (/admin/merchants)
-  # Then I see the names of the top 5 merchants by total revenue generated
-  # And I see that each merchant name links to the admin merchant show page for that merchant
-  # And I see the total revenue generated next to each merchant name
-
-  # Notes on Revenue Calculation:
-  # - Only invoices with at least one successful transaction should count towards revenue
-  # - Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
-  # - Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
   # US 30
   it "displays the top 5 merchants by total revenue and lists total revenue generated" do
     visit admin_merchants_path
+  
+    puts "Merchant 1 ID: #{@merchant1.id}"
 
-    save_and_open_page
-    expect("#{@merchant1.name}: #{@merchant1.total_revenue}").to appear_before("#{@merchant2.name}: #{@merchant2.total_revenue}")
-
-    within("#admin-#{@merchant1.id}") do
-      expect(page).to have_content("#{@merchant1.name}: #{@total_revenue1}")
+    within("#merchant-#{@merchant1.id}") do
+      expect(page).to have_content("#{@merchant1.name}: $#{@merchant1.total_revenue1}")
       expect(page).to have_link("#{@merchant1.name} ##{@merchant1.id}")
       click_link("#{@merchant1.name} ##{@merchant1.id}")
     end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,9 +2,33 @@ require 'rails_helper'
 
 RSpec.describe "Admin Merchants Index", type: :feature do
   before :each do
+    # Create merchants
     @merchant1 = create(:merchant)
     @merchant2 = create(:merchant)
     @merchant3 = create(:merchant)
+    @merchant4 = create(:merchant)
+    @merchant5 = create(:merchant)
+
+    # Create invoices with successful transactions
+    @invoice1 = create(:invoice) # No need to associate with a merchant
+    @invoice2 = create(:invoice) # No need to associate with a merchant
+    @invoice3 = create(:invoice) # No need to associate with a merchant
+    @invoice4 = create(:invoice) # No need to associate with a merchant
+    @invoice5 = create(:invoice) # No need to associate with a merchant
+
+    # Create invoice items with unit prices and quantities associated with invoices
+    @invoice_item1 = create(:invoice_item, invoice: @invoice1, unit_price: 10, quantity: 5)
+    @invoice_item2 = create(:invoice_item, invoice: @invoice2, unit_price: 15, quantity: 3)
+    @invoice_item3 = create(:invoice_item, invoice: @invoice3, unit_price: 8, quantity: 5)
+    @invoice_item4 = create(:invoice_item, invoice: @invoice4, unit_price: 9, quantity: 4)
+    @invoice_item5 = create(:invoice_item, invoice: @invoice5, unit_price: 9, quantity: 2)
+
+    # Create successful transactions for invoices
+    @transaction1 = create(:transaction, invoice: @invoice1, result: 0) # Successful
+    @transaction2 = create(:transaction, invoice: @invoice2, result: 0) # Successful
+    @transaction3 = create(:transaction, invoice: @invoice3, result: 0) # Successful
+    @transaction4 = create(:transaction, invoice: @invoice4, result: 0) # Successful
+    @transaction5 = create(:transaction, invoice: @invoice5, result: 0) # Successful
   end
 
   # US 24
@@ -16,10 +40,6 @@ RSpec.describe "Admin Merchants Index", type: :feature do
     expect(page).to have_content(@merchant3.name)
   end
 
-  #   As an admin,
-# When I click on the name of a merchant from the admin merchants index page (/admin/merchants),
-# Then I am taken to that merchant's admin show page (/admin/merchants/:merchant_id)
-# And I see the name of that merchant
   # US 25
   it "clicking the name redirects to merchant admin show page and displays the name" do
     visit admin_merchants_path
@@ -30,5 +50,31 @@ RSpec.describe "Admin Merchants Index", type: :feature do
     expect(current_path).to eq(admin_merchant_path(@merchant1.id))
 
     expect(page).to have_content(@merchant1.name)
+  end
+
+  # As an admin,
+  # When I visit the admin merchants index (/admin/merchants)
+  # Then I see the names of the top 5 merchants by total revenue generated
+  # And I see that each merchant name links to the admin merchant show page for that merchant
+  # And I see the total revenue generated next to each merchant name
+
+  # Notes on Revenue Calculation:
+  # - Only invoices with at least one successful transaction should count towards revenue
+  # - Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
+  # - Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
+  # US 30
+  it "displays the top 5 merchants by total revenue and lists total revenue generated" do
+    visit admin_merchants_path
+
+    save_and_open_page
+    expect("#{@merchant1.name}: #{@merchant1.total_revenue}").to appear_before("#{@merchant2.name}: #{@merchant2.total_revenue}")
+
+    within("#admin-#{@merchant1.id}") do
+      expect(page).to have_content("#{@merchant1.name}: #{@total_revenue1}")
+      expect(page).to have_link("#{@merchant1.name} ##{@merchant1.id}")
+      click_link("#{@merchant1.name} ##{@merchant1.id}")
+    end
+
+    expect(current_path).to eq(admin_merchant_path(@merchant1.id))
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,15 +2,11 @@ require 'rails_helper'
 
 RSpec.describe "Admin Merchants Index", type: :feature do
   before :each do
-    # Create merchants
     @merchant1 = create(:merchant)
     @merchant2 = create(:merchant)
     @merchant3 = create(:merchant)
     @merchant4 = create(:merchant)
     @merchant5 = create(:merchant)
-
-    puts "Merchant 1 ID: #{@merchant1.id}"
-    puts "Merchant 1 Name: #{@merchant1.name}"
 
     @customer1 = create(:customer)
     @customer2 = create(:customer)
@@ -31,11 +27,11 @@ RSpec.describe "Admin Merchants Index", type: :feature do
     @item5 = create(:item, merchant: @merchant5)
 
     # Create invoice items with unit prices and quantities associated with invoices
-    @invoice_item1 = create(:invoice_item, invoice: @invoice1, unit_price: 10, quantity: 5)
-    @invoice_item2 = create(:invoice_item, invoice: @invoice2, unit_price: 15, quantity: 3)
-    @invoice_item3 = create(:invoice_item, invoice: @invoice3, unit_price: 8, quantity: 5)
-    @invoice_item4 = create(:invoice_item, invoice: @invoice4, unit_price: 9, quantity: 4)
-    @invoice_item5 = create(:invoice_item, invoice: @invoice5, unit_price: 9, quantity: 2)
+    @invoice_item1 = create(:invoice_item, item: @item1, invoice: @invoice1, unit_price: 10, quantity: 5)
+    @invoice_item2 = create(:invoice_item, item: @item2, invoice: @invoice2, unit_price: 15, quantity: 3)
+    @invoice_item3 = create(:invoice_item, item: @item3, invoice: @invoice3, unit_price: 8, quantity: 5)
+    @invoice_item4 = create(:invoice_item, item: @item4, invoice: @invoice4, unit_price: 9, quantity: 4)
+    @invoice_item5 = create(:invoice_item, item: @item5, invoice: @invoice5, unit_price: 9, quantity: 2)
 
     # Create successful transactions for invoices
     @transaction1 = create(:transaction, invoice: @invoice1, result: 0) # Successful
@@ -58,26 +54,31 @@ RSpec.describe "Admin Merchants Index", type: :feature do
   it "clicking the name redirects to merchant admin show page and displays the name" do
     visit admin_merchants_path
 
-    expect(page).to have_link("#{@merchant1.name} ##{@merchant1.id}")
-    click_link("#{@merchant1.name} ##{@merchant1.id}")
-
-    expect(current_path).to eq(admin_merchant_path(@merchant1.id))
+    within("#merchant-#{@merchant1.id}") do
+      expect(page).to have_link("#{@merchant1.name} ##{@merchant1.id}")
+      click_link("#{@merchant1.name} ##{@merchant1.id}")
+      expect(current_path).to eq(admin_merchant_path(@merchant1.id))
+    end
 
     expect(page).to have_content(@merchant1.name)
   end
 
   # US 30
   it "displays the top 5 merchants by total revenue and lists total revenue generated" do
+    puts "Merchant 1 ID: #{@merchant1.id}"
     visit admin_merchants_path
   
-    puts "Merchant 1 ID: #{@merchant1.id}"
+    expect("#{@merchant1.name}: $50").to appear_before("#{@merchant2.name}: $45")
+    expect("#{@merchant2.name}: $45").to appear_before("#{@merchant3.name}: $40")
+    expect("#{@merchant3.name}: $40").to appear_before("#{@merchant4.name}: $36")
+    expect("#{@merchant4.name}: $36").to appear_before("#{@merchant5.name}: $18")
+    expect("#{@merchant5.name}: $18").to_not appear_before("#{@merchant1.name}: $50")
 
-    within("#merchant-#{@merchant1.id}") do
-      expect(page).to have_content("#{@merchant1.name}: $#{@merchant1.total_revenue1}")
+    within("#top_5-#{@merchant1.id}") do
+      expect(page).to have_content("#{@merchant1.name}: $50")
       expect(page).to have_link("#{@merchant1.name} ##{@merchant1.id}")
       click_link("#{@merchant1.name} ##{@merchant1.id}")
+      expect(current_path).to eq(admin_merchant_path(@merchant1.id))
     end
-
-    expect(current_path).to eq(admin_merchant_path(@merchant1.id))
   end
 end

--- a/spec/features/admin/welcome_spec.rb
+++ b/spec/features/admin/welcome_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "admin dashboard index page" do
   end
 
   #user story 21
-  xit "Displays the names of the top 5 customers" do
+  it "Displays the names of the top 5 customers" do
     # visit("/admin")
     visit admin_path
     expect(page).to have_content("1. #{@customer_1.first_name} #{@customer_1.last_name} - 5 transactions")
@@ -78,7 +78,7 @@ RSpec.describe "admin dashboard index page" do
   end
 
   #user story 22 & 23
-  xit "Displays incomplete invoices with oldest first" do
+  it "Displays incomplete invoices with oldest first" do
     visit admin_path
     invoice_1 = find_link(@invoice_item_1.invoice_id)
     invoice_2 = find_link(@invoice_item_2.invoice_id)
@@ -93,6 +93,5 @@ RSpec.describe "admin dashboard index page" do
     expect(page).to have_link("#{@invoice_item_1.invoice_id}")
     click_link("#{@invoice_item_1.invoice_id}")
     expect(current_path).to eq("/admin/invoices/#{@invoice_item_1.invoice_id}")
-  
   end
 end


### PR DESCRIPTION
30. Admin Merchants: Top 5 Merchants by Revenue

As an admin,
When I visit the admin merchants index (/admin/merchants)
Then I see the names of the top 5 merchants by total revenue generated
And I see that each merchant name links to the admin merchant show page for that merchant
And I see the total revenue generated next to each merchant name

Notes on Revenue Calculation:
- Only invoices with at least one successful transaction should count towards revenue
- Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
- Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)

Debugged the spec test