### PR TITLE
Admin/merchants/us 31

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -77,6 +77,7 @@ class Merchant < ApplicationRecord
     .select('merchants.*, SUM(invoice_items.unit_price * invoice_items.quantity) AS total_revenue')  # Calculate total revenue
     .group('merchants.id') # group records by merchant
     .order('total_revenue DESC')
+    .limit(5) #added because the server was returning more than 5
   end
 
   def best_day

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -78,4 +78,12 @@ class Merchant < ApplicationRecord
     .group('merchants.id') # group records by merchant
     .order('total_revenue DESC')
   end
+
+  def best_day
+    invoices.joins(:items)
+      .group("invoices.created_at")
+      .sum("invoice_items.quantity * items.unit_price")
+      .max_by { |date, sales| sales }
+      .first
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,6 +1,7 @@
 <h1> Index of Admin Merchants </h1>
 <br>
 <h3>Top 5 Merchants by Revenue</h3>
+<section id="all_top_5">
 <% @merchants.top_five_merchants_by_revenue.each do |merchant| %>
   <div id="top_5-<%= merchant.id %>"> 
     <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
@@ -9,7 +10,8 @@
   </div>
 <% end %>
 <br>
-<h3>
+</section>
+</section>
 
 <section id="enabled-merchants">
   <h3>Enabled Merchants</h3>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -5,6 +5,7 @@
   <div id="top_5-<%= merchant.id %>"> 
     <%= link_to "#{merchant.name} ##{merchant.id}", admin_merchant_path(merchant.id) %><br>
     <p><%= merchant.name %>: $<%= merchant.total_revenue %></p>
+    <p><%="top selling date #{merchant.best_day.strftime("%m/%d/%y")}" %>
   </div>
 <% end %>
 <br>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -108,4 +108,11 @@ RSpec.describe "Admin Merchants Index", type: :feature do
       expect(current_path).to eq(admin_merchant_path(@merchant1.id))
     end
   end
+
+  #US 31
+  it "displays the date of the top 5 merchants most profitable days" do 
+    visit admin_merchants_path
+    within("all_top_5")
+      expect(page).to have_content(Date.today.strftime("%m/%d/%y"))
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -145,5 +145,11 @@ RSpec.describe Merchant, type: :model do
         expect(Merchant.disabled_merchants).to eq(expected)
       end
     end
+
+    describe "best_day" do
+      it "returns a merchant's highest invoiced day" do
+        expect(@merchant.best_day.to_date).to eq(Date.today)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a AR method to the merchant class to return a merchant's best day, and then added it to the view within the top 5 merchants iteration. 

31. Admin Merchants: Top Merchant's Best Day

As an admin,
When I visit the admin merchants index
Then next to each of the 5 merchants by revenue I see the date with the most revenue for each merchant.
And I see a label “Top selling date for <merchant name> was <date with most sales>"

Note: use the invoice date. If there are multiple days with equal number of sales, return the most recent day.